### PR TITLE
Make fromAccountId and toAccountId projectable to avoid hybrid queries

### DIFF
--- a/src/main/java/org/perf/invokers/ReserveInvoker.java
+++ b/src/main/java/org/perf/invokers/ReserveInvoker.java
@@ -85,7 +85,7 @@ public class ReserveInvoker implements Invoker {
         Query<Object[]> query = queryFactory.create(
                 "select fromAccountId, toAccountId, action, amount FROM uetraction.UETRAction WHERE fromAccountId = :accountId or toAccountId = :accountId");
         query.setParameter("accountId", accountId);
-        List<Object[]> list = query.maxResults(1000).hitCountAccuracy(10).execute().list();
+        List<Object[]> list = query.maxResults(1000).hitCountAccuracy(10).list();
 
         return list.stream()
                 .map(action -> new BigDecimal((String) action[3]))

--- a/src/main/java/org/perf/model/UETRAction.java
+++ b/src/main/java/org/perf/model/UETRAction.java
@@ -13,11 +13,11 @@ public class UETRAction implements Serializable {
 
     private static final long serialVersionUID = 1434254484114366251L;
     @ProtoField(number = 1)
-    @Basic
+    @Basic(projectable = true)
     String fromAccountId;
 
     @ProtoField(number = 2)
-    @Basic
+    @Basic(projectable = true)
     String toAccountId;
 
     @ProtoField(number = 3)


### PR DESCRIPTION
Plus use .list() instead of using .execute().list(), since we don't use the hit count